### PR TITLE
Add displayName to icons

### DIFF
--- a/packages/generate-icon-lib/src/templates/named-icon.tsx.ejs
+++ b/packages/generate-icon-lib/src/templates/named-icon.tsx.ejs
@@ -92,4 +92,6 @@ export const <%- iconToComponentName(icon) %> = React.forwardRef<SVGSVGElement, 
 );
 <% } %>
 
+<%- iconToComponentName(icon) %>.displayName = <%- iconToComponentName(icon) %>;
+
 export default <%- iconToComponentName(icon) %>;


### PR DESCRIPTION
Fixes #124 (not tested)

---

PR checklist:

- [ ] Figma: icon shapes use “Scale” constraint
- [ ] Figma: icon components are sorted Z-A in the file
- [ ] Figma: icon components are built with a single union or compound shape when possible
- [ ] Figma: library changes are published
- [ ] SVG: icons render correctly in a browser
- [ ] SVG: icons are exported with `width="15" height="15" viewBox="0 0 15 15"`
- [ ] SVG: no icons are exported with `stroke`
- [ ] SVG: no icons are exported with `clip-path`
- [ ] SVG: no icons exceed 5 KB
- [ ] Website is up to date
- [ ] Sketch file is up to date
- [ ] IconJar file is up to date
  - [ ] Icon names in the IconJar library are correct
  - [ ] Version in the IconJar library description is correct
