### PR TITLE
Support React 18

### DIFF
--- a/packages/radix-icons/package.json
+++ b/packages/radix-icons/package.json
@@ -29,7 +29,7 @@
     "prepublishOnly": "npm run build"
   },
   "peerDependencies": {
-    "react": "^16.x || ^17.x"
+    "react": "^16.x || ^17.x || ^18.x"
   },
   "devDependencies": {
     "@modulz/generate-icon-lib": "^0.2.0",


### PR DESCRIPTION
A few users have reported the install warnings, so we should update and publish a new release.

I think that's all that's needed here to support React 18, but I'm not super familiar with the generator part, so maybe I've missed something.