### PR TITLE
fix: Use `Object.defineProperty` to assign the `__esModule` flag

### DIFF
--- a/packages/radix-icons/index.js
+++ b/packages/radix-icons/index.js
@@ -1,2 +1,5 @@
 module.exports = require('./dist/index.js');
-module.exports.__esModule = true;
+
+Object.defineProperty(module.exports, '__esModule', {
+  value: true
+});


### PR DESCRIPTION
This PR changes the direct assignment `module.exports.__esModule = true` to use `Object.defineProperty` instead, as the `__esModule` is usually considered as a read only key and that assignment will cause errors in many bundlers including Webpack. One example: https://github.com/facebook/create-react-app/issues/2602.

---

PR checklist:

- [ ] Figma: icon shapes use “Scale” constraint
- [ ] Figma: icon components are sorted Z-A in the file
- [ ] Figma: icon components are built with a single union or compound shape when possible
- [ ] Figma: library changes are published
- [ ] SVG: icons render correctly in a browser
- [ ] SVG: icons are exported with `width="15" height="15" viewBox="0 0 15 15"`
- [ ] SVG: no icons are exported with `stroke`
- [ ] SVG: no icons are exported with `clip-path`
- [ ] SVG: no icons exceed 5 KB
- [ ] Website is up to date
- [ ] Sketch file is up to date
- [ ] IconJar file is up to date
  - [ ] Icon names in the IconJar library are correct
  - [ ] Version in the IconJar library description is correct
