### PR TITLE
Add sideEffects: false to support treeshaking

### DIFF
--- a/packages/radix-icons/package.json
+++ b/packages/radix-icons/package.json
@@ -19,6 +19,7 @@
     "index.js",
     "manifest.json"
   ],
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
From looking through the repo, it looks like there aren't any sideffects to the code as its looks like the icons are just wrapped in React containers. 

Can we therefore add `  "sideEffects": false,` to the package json to support  ES6 treeshaking and bring down the bundle size?

---

I'm assuming all of the following are up to date , as there were no other changes

PR checklist:

- [ ] Figma: icon shapes use “Scale” constraint
- [ ] Figma: icon components are sorted Z-A in the file
- [ ] Figma: icon components are built with a single union or compound shape when possible
- [ ] Figma: library changes are published
- [ ] SVG: icons render correctly in a browser
- [ ] SVG: icons are exported with `width="15" height="15" viewBox="0 0 15 15"`
- [ ] SVG: no icons are exported with `stroke`
- [ ] SVG: no icons are exported with `clip-path`
- [ ] SVG: no icons exceed 5 KB
- [ ] Website is up to date
- [ ] Sketch file is up to date
- [ ] IconJar file is up to date
- [ ] Icon names in the IconJar library are correct
- [ ] Version in the IconJar library description is correct
