### PR TITLE
feat: adds Framer component

### DIFF
--- a/packages/website/pages/index.tsx
+++ b/packages/website/pages/index.tsx
@@ -107,7 +107,7 @@ export default function Home() {
                         onClick={() => {
                           // Copy Framer Component link to clipboard
                           // If pasted directly into Framer, it will be auto-imported
-                          navigator.clipboard.writeText("https://framer.com/projects/Radix--q3HRzQOA8fbasQf6a551-dmfdD?node=p5DztUrSx")
+                          navigator.clipboard.writeText("https://framer.com/m/RadixIcon-6KvN.js")
 
                           // Also would be nice to show a Toast indicating successful copying
                         }}

--- a/packages/website/pages/index.tsx
+++ b/packages/website/pages/index.tsx
@@ -104,6 +104,20 @@ export default function Home() {
                         Download for Sketch
                       </IconLink>
                       <IconLink
+                        onClick={() => {
+                          // Copy Framer Component link to clipboard
+                          // If pasted directly into Framer, it will be auto-imported
+                          navigator.clipboard.writeText("https://framer.com/projects/Radix--q3HRzQOA8fbasQf6a551-dmfdD?node=p5DztUrSx")
+
+                          // Also would be nice to show a Toast indicating successful copying
+                        }}
+                      >
+                        <Box as="span" css={{ mr: '$2' }}>
+                          <FramerLogoIcon />
+                        </Box>
+                        Copy for Framer
+                      </IconLink>
+                      <IconLink
                         href="https://raw.githubusercontent.com/radix-ui/icons/master/Radix-Icons.iconjar.zip"
                         target="_blank"
                       >


### PR DESCRIPTION
👋 Hello, thanks for the lovely icons!

I was using them in a project and needed an easy way to use them within Framer. Ended up writing a small HOC that can be pasted into Framer, allows changing the dimensions, picking a colour and selecting any icon from the list.

Made this quick PR to add it under the "Assets" section of the website,  in case it might come in handy for others. Adding a small GIF to show how it works.

![radix-framer](https://github.com/radix-ui/icons/assets/30227512/3b41a3f4-50eb-47f8-8c2d-5673fe0f4f45)





---

PR checklist:

(No changes that would affect the below)

- [x] Figma: icon shapes use “Scale” constraint
- [x] Figma: icon components are sorted Z-A in the file
- [x] Figma: icon components are built with a single union or compound shape when possible
- [x] Figma: library changes are published
- [x] SVG: icons render correctly in a browser
- [x] SVG: icons are exported with `width="15" height="15" viewBox="0 0 15 15"`
- [x] SVG: no icons are exported with `stroke`
- [x] SVG: no icons are exported with `clip-path`
- [x] SVG: no icons exceed 5 KB
- [x] Website is up to date
- [x] Sketch file is up to date
- [x] IconJar file is up to date
  - [x] Icon names in the IconJar library are correct
  - [x] Version in the IconJar library description is correct
