### PR TITLE
deps: update react peer deps

### DIFF
--- a/packages/radix-icons/package.json
+++ b/packages/radix-icons/package.json
@@ -30,7 +30,7 @@
     "prepublishOnly": "npm run build"
   },
   "peerDependencies": {
-    "react": "^16.x || ^17.x || ^18.x || ^19.x"
+    "react": "^16.x || ^17.x || ^18.x || ^19.0.0 || ^19.0.0-rc"
   },
   "devDependencies": {
     "@modulz/generate-icon-lib": "^0.2.1",


### PR DESCRIPTION
Follow up from #184. Since React 19 does not have a `.0` release, we need to update the peer deps version. 

@lucasmotta can you take a look when you got a min please? Thank you. 